### PR TITLE
fix: "Missing figureCaption submodule" error on Project R newsletter

### DIFF
--- a/packages/template-newsletter/src/web/index.js
+++ b/packages/template-newsletter/src/web/index.js
@@ -210,7 +210,7 @@ const schema = {
                   props: (node, index, parent) => ({
                     data: (parent && parent.data) || {}
                   }),
-                  editorModule: 'paragraph',
+                  editorModule: 'figureCaption',
                   editorOptions: {
                     type: 'figureCaption',
                     placeholder: 'Legende'


### PR DESCRIPTION
Discovered while working on https://github.com/orbiting/styleguide/pull/67/files where this change fixed the issue for the editorial newsletter template.