### PR TITLE
Add zone errors to mdast metadata when serializing

### DIFF
--- a/packages/remark-preset/src/zone.js
+++ b/packages/remark-preset/src/zone.js
@@ -53,10 +53,10 @@ export const collapse = ({test, mutate}) => () => {
       })
     } else {
       if (collected.start) {
-        console.warn(
-          'zone not ended',
-          collected.start
-        )
+        const error = 'zone not ended'
+        console.warn(error, collected.start);
+        parent.meta.errors = [error];
+
       }
       parent.children.forEach(node => {
         collectZones(node)


### PR DESCRIPTION
In order to detect (and act upon) zone errors