### PR TITLE
fix(span): harden data attribute value parsing

### DIFF
--- a/packages/remark-preset/src/span.js
+++ b/packages/remark-preset/src/span.js
@@ -19,10 +19,8 @@ export const collapse = zone.collapse({
     const data = {}
     const dataAttrs = start.value.match(/data-([^=]+)="([^"]+)"/g) || []
     dataAttrs.forEach(d => {
-      const [key, value] = d.split('=')
-      data[
-        decodeEntities(key.replace(/^data-/, ''))
-      ] = decodeEntities(value.slice(1, -1))
+      const [, key, value] = d.match(/^data-(.+?)="(.+)"/)
+      data[decodeEntities(key)] = decodeEntities(value)
     })
     return {
       type: 'span',

--- a/packages/remark-preset/src/span.test.js
+++ b/packages/remark-preset/src/span.test.js
@@ -57,3 +57,33 @@ test('span data is string only', assert => {
 
   assert.end()
 })
+
+test('span data contains equal sign', assert => {
+  const md = '<span data-attr="foo=bar">child</span>\n'
+  const rootNode = parse(md)
+
+  const { data } = rootNode.children[0].children[0]
+
+  assert.equal(data.attr, 'foo=bar')
+  assert.end()
+})
+
+test('span data contains multiple equal signs', assert => {
+  const md = '<span data-attr="foo=bar, fizz=buzz">child</span>\n'
+  const rootNode = parse(md)
+
+  const { data } = rootNode.children[0].children[0]
+
+  assert.equal(data.attr, 'foo=bar, fizz=buzz')
+  assert.end()
+})
+
+test('span data contains data attribute resembling data', assert => {
+  const md = '<span data-attr="data-hero=&#x22;Spiderman&#x22;">child</span>\n'
+  const rootNode = parse(md)
+
+  const { data } = rootNode.children[0].children[0]
+
+  assert.equal(data.attr, 'data-hero="Spiderman"')
+  assert.end()
+})


### PR DESCRIPTION
affects: @orbiting/remark-preset

If data attribute value contained an equal sign, parsing messed up.